### PR TITLE
Add daily calibration and test run scripts for USGS gage 03463300

### DIFF
--- a/SPOTPY_DDS_setup.py
+++ b/SPOTPY_DDS_setup.py
@@ -1,0 +1,69 @@
+"""
+SPOTPY setup file
+
+Author: Abhinav Gupta (Created: 9 Feb 2026)
+"""
+
+import numpy as np
+from spotpy.parameter import Uniform, List
+import snow17_pet_cfe
+import os
+import spotpy
+
+class spotpy_setup(object):
+    def __init__(self, param_range, area_km2, warmup_days, met_df_cal, dates_cal, qobs_cal, initial_snow_state, initial_cfe_state, lat, elev, time_step_size, time_step_units):
+        
+        self.parameternames=param_range.keys()
+        self.params=[]
+        for parname in self.parameternames:
+            low, high, discrete_flag = param_range[parname]
+            if discrete_flag == 1:
+                self.params.append(List(parname, list(low)))
+            else:
+                self.params.append(spotpy.parameter.Uniform(parname, low, high))
+
+        self.dim = len(self.params)
+
+        self.area_km2 = area_km2
+        self.warmup_days = warmup_days
+        self.met_df_cal = met_df_cal
+        self.dates_cal = dates_cal
+        self.observations = qobs_cal
+        self.initial_snow_state = initial_snow_state
+        self.initial_cfe_state = initial_cfe_state
+        self.lat = lat
+        self.elev = elev
+        self.time_step_size = time_step_size
+        self.time_step_units = time_step_units
+
+
+    def parameters(self):           
+        return spotpy.parameter.generate(self.params)
+
+    def simulation(self, params):
+        pet_params = {'alpha_PT': params[0]}
+        snow_params = {'scf': params[1], 'rvs': params[2], 'uadj': params[3], 'mbase': params[4], 'mfmax': params[5], 'mfmin': params[6], 
+                         'tipm': params[7], 'nmf': params[8], 'plwhc': params[9], 'pxtemp': params[10], 'pxtemp1': params[11], 'pxtemp2': params[12]}
+        cfg_data = {
+            "catchment_area_km2": self.area_km2,
+            "partition_scheme":"Schaake",
+            "soil_params":{"bb":params[13], "satdk":params[14], "satpsi":params[15], "slop":params[16], "smcmax":params[17], "wltsmc":params[18], "D":params[19], "K_lf":params[20], "alpha_fc":params[21]},
+            "max_gw_storage":params[22], "Cgw":params[23], "expon":params[24],
+            "K_nash_lateral":params[25], "nash_storage_lateral":[0.0]*int(params[26]), "K_nash_surface":params[27], "nash_storage_surface":[0.0]*int(params[28]), "refkdt":params[29], 'trigger_z_m': params[30],
+            "soil_scheme":"classic",
+            "stand_alone": 0,
+}        
+
+        output_lists, _ = snow17_pet_cfe.run_snow_pet_cfe(self.met_df_cal, self.dates_cal, cfg_data,
+                                                           snow_params, pet_params, self.initial_snow_state, 
+                                                           self.initial_cfe_state, self.lat, self.elev, 
+                                                           self.time_step_size, self.time_step_units)
+        simulations = np.array(output_lists['land_surface_water__runoff_depth'])*1000.0
+        return simulations[self.warmup_days:]
+
+    def evaluation(self):
+        return self.observations
+
+    def objectivefunction(self,simulation,evaluation):
+        objectivefunction = -1*np.mean(np.abs(simulation - evaluation))     # -1 because the DDS in SPOTPY maximizes the ojective function, but we want to minimize the mean absolute error between simulation and evaluation
+        return objectivefunction

--- a/download_usgs_obs.py
+++ b/download_usgs_obs.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+download_usgs_obs.py — Download clean USGS daily & hourly observations for gage 03463300.
+
+Pulls directly from USGS Water Services API.
+Raw data is in CFS (cubic feet per second).
+Converts to mm/day (daily) or mm/hr (hourly) using drainage area.
+
+USGS gage 03463300: South Toe River Near Celo, NC
+  Drainage area: 43.3 sq mi = 112.14 km²
+
+Usage:
+    python3 download_usgs_obs.py --output-dir ./gage_03463300_data
+"""
+
+import argparse
+import os
+import pandas as pd
+import numpy as np
+import requests
+import time as time_module
+
+SITE_NO = "03463300"
+DRAINAGE_AREA_SQ_MI = 43.3
+DRAINAGE_AREA_KM2 = DRAINAGE_AREA_SQ_MI * 2.58999  # = 112.14 km²
+
+
+def cfs_to_mm_per_day(q_cfs, area_km2):
+    """Convert CFS → mm/day."""
+    return q_cfs * 0.028317 * 86400.0 * 1000.0 / (area_km2 * 1.0e6)
+
+
+def cfs_to_mm_per_hr(q_cfs, area_km2):
+    """Convert CFS → mm/hr."""
+    return q_cfs * 0.028317 * 3600.0 * 1000.0 / (area_km2 * 1.0e6)
+
+
+def cfs_to_cms(q_cfs):
+    """Convert CFS → m³/s."""
+    return q_cfs * 0.028317
+
+
+def parse_rdb(text):
+    """Parse USGS RDB format text into a DataFrame."""
+    lines = text.strip().split('\n')
+    data_lines = [l for l in lines if not l.startswith('#')]
+    
+    if len(data_lines) < 3:
+        return pd.DataFrame()
+    
+    header = data_lines[0].split('\t')
+    data = []
+    for line in data_lines[2:]:
+        if line.strip():
+            data.append(line.split('\t'))
+    
+    return pd.DataFrame(data, columns=header)
+
+
+def download_daily_values(site_no, start_date, end_date):
+    """Download daily mean discharge from USGS."""
+    url = "https://waterservices.usgs.gov/nwis/dv/"
+    params = {
+        "format": "rdb",
+        "sites": site_no,
+        "parameterCd": "00060",
+        "startDT": start_date,
+        "endDT": end_date,
+        "siteStatus": "all",
+        "statCd": "00003",
+    }
+    
+    print(f"  Fetching daily values: {start_date} to {end_date}")
+    resp = requests.get(url, params=params)
+    resp.raise_for_status()
+    
+    df = parse_rdb(resp.text)
+    if df.empty:
+        print(f"  WARNING: No data returned!")
+        return pd.DataFrame()
+    
+    discharge_col = [c for c in df.columns if '00060' in c and '_cd' not in c]
+    if not discharge_col:
+        print(f"  WARNING: No discharge column found!")
+        return pd.DataFrame()
+    
+    q_col = discharge_col[-1]
+    
+    result = pd.DataFrame()
+    result['time'] = pd.to_datetime(df['datetime'])
+    result['discharge_cfs'] = pd.to_numeric(df[q_col], errors='coerce')
+    result = result.dropna()
+    
+    print(f"  Got {len(result)} daily records")
+    print(f"  CFS range: {result['discharge_cfs'].min():.1f} – {result['discharge_cfs'].max():.1f}")
+    
+    return result
+
+
+def download_iv_values(site_no, start_date, end_date):
+    """Download instantaneous (15-min) discharge from USGS IV service.
+    
+    USGS IV service limits requests to ~120 days at a time.
+    We chunk into 90-day windows to be safe.
+    """
+    url = "https://waterservices.usgs.gov/nwis/iv/"
+    
+    all_data = []
+    start = pd.to_datetime(start_date)
+    end = pd.to_datetime(end_date)
+    chunk_days = 90
+    
+    current = start
+    while current < end:
+        chunk_end = min(current + pd.Timedelta(days=chunk_days), end)
+        
+        params = {
+            "format": "rdb",
+            "sites": site_no,
+            "parameterCd": "00060",
+            "startDT": current.strftime("%Y-%m-%d"),
+            "endDT": chunk_end.strftime("%Y-%m-%d"),
+            "siteStatus": "all",
+        }
+        
+        print(f"  Fetching IV: {current.strftime('%Y-%m-%d')} to {chunk_end.strftime('%Y-%m-%d')}...", end="")
+        try:
+            resp = requests.get(url, params=params, timeout=120)
+            resp.raise_for_status()
+            
+            df = parse_rdb(resp.text)
+            if not df.empty:
+                discharge_col = [c for c in df.columns if '00060' in c and '_cd' not in c]
+                if discharge_col:
+                    q_col = discharge_col[-1]
+                    chunk_df = pd.DataFrame()
+                    chunk_df['time'] = pd.to_datetime(df['datetime'])
+                    chunk_df['discharge_cfs'] = pd.to_numeric(df[q_col], errors='coerce')
+                    chunk_df = chunk_df.dropna()
+                    all_data.append(chunk_df)
+                    print(f" {len(chunk_df)} records")
+                else:
+                    print(f" no discharge column")
+            else:
+                print(f" empty")
+        except Exception as e:
+            print(f" ERROR: {e}")
+        
+        current = chunk_end + pd.Timedelta(days=1)
+        time_module.sleep(1)  # Be nice to USGS servers
+    
+    if not all_data:
+        return pd.DataFrame()
+    
+    result = pd.concat(all_data, ignore_index=True)
+    result = result.sort_values('time').drop_duplicates(subset='time')
+    
+    print(f"  Total IV records: {len(result)}")
+    print(f"  CFS range: {result['discharge_cfs'].min():.1f} – {result['discharge_cfs'].max():.1f}")
+    
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download USGS observations for gage 03463300")
+    parser.add_argument('--output-dir', type=str, default='./gage_03463300_data')
+    parser.add_argument('--skip-hourly', action='store_true', help="Skip hourly IV download (slow)")
+    args = parser.parse_args()
+    
+    os.makedirs(args.output_dir, exist_ok=True)
+    
+    area_km2 = DRAINAGE_AREA_KM2
+    print(f"USGS Gage: {SITE_NO} (South Toe River Near Celo, NC)")
+    print(f"Drainage area: {DRAINAGE_AREA_SQ_MI} sq mi = {area_km2:.2f} km²")
+    print()
+    
+    # =========================================
+    # DAILY: CALIBRATION (2018-2022)
+    # =========================================
+    print("=" * 60)
+    print("DAILY — CALIBRATION PERIOD (2018-2022)")
+    print("=" * 60)
+    
+    df_cal = download_daily_values(SITE_NO, "2018-01-01", "2022-12-31")
+    
+    if len(df_cal) > 0:
+        df_cal['streamflow_mm_day'] = cfs_to_mm_per_day(df_cal['discharge_cfs'], area_km2)
+        df_cal['streamflow_cms'] = cfs_to_cms(df_cal['discharge_cfs'])
+        
+        print(f"  mm/day range: {df_cal['streamflow_mm_day'].min():.2f} – {df_cal['streamflow_mm_day'].max():.2f}")
+        
+        # Save full version
+        df_cal[['time', 'streamflow_mm_day', 'discharge_cfs', 'streamflow_cms']].to_csv(
+            os.path.join(args.output_dir, 'obs_usgs_daily_cal.csv'), index=False)
+        # Save compatible version (streamflow in m³/s for existing scripts)
+        pd.DataFrame({'time': df_cal['time'], 'streamflow': df_cal['streamflow_cms']}).to_csv(
+            os.path.join(args.output_dir, 'obs_usgs_daily_cal_cms.csv'), index=False)
+        print(f"  Saved: obs_usgs_daily_cal.csv, obs_usgs_daily_cal_cms.csv")
+    
+    # =========================================
+    # DAILY: TEST (Sep-Oct 2024)
+    # =========================================
+    print()
+    print("=" * 60)
+    print("DAILY — TEST PERIOD (Sep-Oct 2024)")
+    print("=" * 60)
+    
+    df_test = download_daily_values(SITE_NO, "2024-09-01", "2024-10-31")
+    
+    if len(df_test) > 0:
+        df_test['streamflow_mm_day'] = cfs_to_mm_per_day(df_test['discharge_cfs'], area_km2)
+        df_test['streamflow_cms'] = cfs_to_cms(df_test['discharge_cfs'])
+        
+        print(f"  mm/day range: {df_test['streamflow_mm_day'].min():.2f} – {df_test['streamflow_mm_day'].max():.2f}")
+        
+        peak = df_test.loc[df_test['discharge_cfs'].idxmax()]
+        print(f"\n  HURRICANE HELENE PEAK:")
+        print(f"    Date: {peak['time']}")
+        print(f"    {peak['discharge_cfs']:.0f} CFS = {peak['streamflow_cms']:.1f} m³/s = {peak['streamflow_mm_day']:.1f} mm/day")
+        
+        df_test[['time', 'streamflow_mm_day', 'discharge_cfs', 'streamflow_cms']].to_csv(
+            os.path.join(args.output_dir, 'obs_usgs_daily_test.csv'), index=False)
+        pd.DataFrame({'time': df_test['time'], 'streamflow': df_test['streamflow_cms']}).to_csv(
+            os.path.join(args.output_dir, 'obs_usgs_daily_test_cms.csv'), index=False)
+        print(f"  Saved: obs_usgs_daily_test.csv, obs_usgs_daily_test_cms.csv")
+
+    # =========================================
+    # HOURLY: CALIBRATION (2018-2022) from IV data
+    # =========================================
+    if not args.skip_hourly:
+        print()
+        print("=" * 60)
+        print("HOURLY — CALIBRATION PERIOD (2018-2022) [from 15-min IV data]")
+        print("=" * 60)
+        print("  (This will take a few minutes — fetching 5 years of 15-min data)")
+        
+        df_iv_cal = download_iv_values(SITE_NO, "2018-01-01", "2022-12-31")
+        
+        if len(df_iv_cal) > 0:
+            # Resample 15-min → hourly (mean)
+            df_iv_cal = df_iv_cal.set_index('time')
+            df_hourly_cal = df_iv_cal.resample('1h').mean().dropna().reset_index()
+            
+            df_hourly_cal['streamflow_mm_hr'] = cfs_to_mm_per_hr(df_hourly_cal['discharge_cfs'], area_km2)
+            df_hourly_cal['streamflow_cms'] = cfs_to_cms(df_hourly_cal['discharge_cfs'])
+            
+            print(f"  Hourly records: {len(df_hourly_cal)}")
+            print(f"  mm/hr range: {df_hourly_cal['streamflow_mm_hr'].min():.4f} – {df_hourly_cal['streamflow_mm_hr'].max():.2f}")
+            print(f"  m³/s range:  {df_hourly_cal['streamflow_cms'].min():.2f} – {df_hourly_cal['streamflow_cms'].max():.2f}")
+            
+            # Save full version
+            df_hourly_cal[['time', 'streamflow_mm_hr', 'discharge_cfs', 'streamflow_cms']].to_csv(
+                os.path.join(args.output_dir, 'obs_usgs_hourly_cal.csv'), index=False)
+            # Compat: 'streamflow' column in m³/s (for run_cfe_calibration.py which expects m³/s and converts)
+            pd.DataFrame({'time': df_hourly_cal['time'], 'streamflow': df_hourly_cal['streamflow_cms']}).to_csv(
+                os.path.join(args.output_dir, 'obs_usgs_hourly_cal_cms.csv'), index=False)
+            print(f"  Saved: obs_usgs_hourly_cal.csv, obs_usgs_hourly_cal_cms.csv")
+        
+        # =========================================
+        # HOURLY: TEST (Sep-Oct 2024) from IV data
+        # =========================================
+        print()
+        print("=" * 60)
+        print("HOURLY — TEST PERIOD (Sep-Oct 2024) [from 15-min IV data]")
+        print("=" * 60)
+        
+        df_iv_test = download_iv_values(SITE_NO, "2024-09-01", "2024-10-31")
+        
+        if len(df_iv_test) > 0:
+            df_iv_test = df_iv_test.set_index('time')
+            df_hourly_test = df_iv_test.resample('1h').mean().dropna().reset_index()
+            
+            df_hourly_test['streamflow_mm_hr'] = cfs_to_mm_per_hr(df_hourly_test['discharge_cfs'], area_km2)
+            df_hourly_test['streamflow_cms'] = cfs_to_cms(df_hourly_test['discharge_cfs'])
+            
+            print(f"  Hourly records: {len(df_hourly_test)}")
+            print(f"  mm/hr range: {df_hourly_test['streamflow_mm_hr'].min():.4f} – {df_hourly_test['streamflow_mm_hr'].max():.2f}")
+            
+            peak = df_hourly_test.loc[df_hourly_test['discharge_cfs'].idxmax()]
+            print(f"\n  HOURLY HELENE PEAK:")
+            print(f"    Time: {peak['time']}")
+            print(f"    {peak['discharge_cfs']:.0f} CFS = {peak['streamflow_cms']:.1f} m³/s = {peak['streamflow_mm_hr']:.2f} mm/hr")
+            
+            df_hourly_test[['time', 'streamflow_mm_hr', 'discharge_cfs', 'streamflow_cms']].to_csv(
+                os.path.join(args.output_dir, 'obs_usgs_hourly_test.csv'), index=False)
+            pd.DataFrame({'time': df_hourly_test['time'], 'streamflow': df_hourly_test['streamflow_cms']}).to_csv(
+                os.path.join(args.output_dir, 'obs_usgs_hourly_test_cms.csv'), index=False)
+            print(f"  Saved: obs_usgs_hourly_test.csv, obs_usgs_hourly_test_cms.csv")
+    
+    # =========================================
+    # SANITY CHECK
+    # =========================================
+    print()
+    print("=" * 60)
+    print("SANITY CHECK")
+    print("=" * 60)
+    print(f"  Drainage area: {area_km2:.2f} km² ({DRAINAGE_AREA_SQ_MI} sq mi)")
+    if len(df_cal) > 0:
+        print(f"  Daily cal peak:  {df_cal['streamflow_mm_day'].max():.1f} mm/day")
+    if len(df_test) > 0:
+        print(f"  Daily test peak: {df_test['streamflow_mm_day'].max():.1f} mm/day")
+    print(f"  Suma expects: ~60-70 mm/day max for typical events")
+    print()
+    print("Files saved to:", args.output_dir)
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/example_gage03463300_config_cfe.json
+++ b/example_gage03463300_config_cfe.json
@@ -1,0 +1,26 @@
+{
+    "forcing_file": "./gage_03463300_data/forcing_2018_2022.csv",
+    "catchment_area_km2": 113.18,
+    "alpha_fc": 0.33,
+    "partition_scheme": "Schaake",
+    "soil_params": {
+        "bb": 4.05,
+        "satdk": 3.38e-06,
+        "satpsi": 0.355,
+        "slop": 1.0,
+        "smcmax": 0.439,
+        "wltsmc": 0.066,
+        "D": 2.0
+    },
+    "max_gw_storage": 16.0,
+    "Cgw": 0.01,
+    "expon": 6.0,
+    "gw_storage": 0.5,
+    "soil_storage": 0.667,
+    "K_lf": 0.01,
+    "K_nash": 0.03,
+    "nash_storage": [0.0, 0.0],
+    "giuh_ordinates": [0.06, 0.51, 0.28, 0.12, 0.03],
+    "stand_alone": 1,
+    "soil_scheme": "ode"
+}

--- a/pet.py
+++ b/pet.py
@@ -1,0 +1,152 @@
+"""
+Modules to compute PET using different methods
+
+Author: Abhinav Gupta (Created: 4 Feb 2026)
+
+"""
+
+import pandas as pd
+import math
+import numpy as np
+
+def net_radiation(srad, tmin, tmax, elev, lat, J, ea, albedo):
+    """
+    Computing net radiation (pandas-based)
+
+    Parameters
+    ----------
+    srad : pd.Series
+        Shortwave solar radiation at earth surface (W/m2)
+    tmin, tmax : pd.Series
+        Minimum and maximum temperature (°C)
+    elev : float
+        Elevation above mean sea level (m)
+    lat : float
+        Latitude (decimal degrees)
+    J : pd.Series or int
+        Julian day of year
+    ea : pd.Series
+        Actual vapor pressure (Pa)
+    albedo : float
+
+    Returns
+    -------
+    Rn_net : pd.Series
+        Net radiation (W/m2)
+    """
+
+    # Emissivity
+    e = 1.0
+
+    # Stefan–Boltzmann constant (W m-2 K-4)
+    sigma = 5.67*10**(-8)
+
+    # Solar constant (MJ m-2 min-1)
+    Gsc = 0.0820
+
+    # Convert vapor pressure from Pa to kPa
+    ea = ea / 1000.0
+
+    # Latitude in radians (scalar)
+    phi = lat*math.pi / 180.0
+
+    # Inverse relative Earth–Sun distance
+    dr = 1.0 + 0.033 * np.cos(2.0 * math.pi * J / 365.0)
+
+    # Solar declination
+    delta = 0.409 * np.sin(2.0 * math.pi * J / 365.0 - 1.39)
+
+    # Sunset hour angle
+    omega_s = np.arccos(-np.tan(phi) * np.tan(delta))
+
+    # Extraterrestrial radiation (MJ m-2 day-1)
+    Ra = (
+        (24.0 * 60.0 / math.pi)
+        * Gsc
+        * dr
+        * (
+            omega_s * np.sin(phi) * np.sin(delta)
+            + np.cos(phi) * np.cos(delta) * np.sin(omega_s)
+        )
+    )
+
+    # Convert Ra to W m-2
+    Ra = Ra / 0.024 / 3.6
+
+    # Clear-sky solar radiation
+    Rs0 = (0.75 + 2*10**(-5) * elev) * Ra
+
+    # Net shortwave radiation
+    Rns = srad * (1.0 - albedo)
+
+    # Relative radiation (capped at 1)
+    relative_radiation = srad / Rs0
+    relative_radiation[relative_radiation > 1.0] = 1.0
+
+    # Net longwave radiation
+    Rnl = (
+        e
+        * sigma
+        * 0.5
+        * ((tmin + 273.15) ** 4 + (tmax + 273.15) ** 4)
+        * (0.34 - 0.14 * ea**0.5)
+        * (1.35 * relative_radiation - 0.35)
+    )
+
+    # Net radiation
+    Rn_net = Rns - Rnl
+
+    return Rn_net
+
+
+def priestley_taylor_fixed_alpha(R_n, G, T, alpha):
+    """
+    Priestley–Taylor potential evapotranspiration (fixed alpha)
+
+    Parameters
+    ----------
+    R_n : np.array
+        Net radiation (W/m2)
+    G : np.array
+        Ground heat flux (W/m2)
+    T : np.array
+        Air temperature (°C)
+    alpha : float
+        Priestley–Taylor coefficient
+
+    Returns
+    -------
+    PET : np.array
+        Potential evapotranspiration (mm/day)
+    """
+
+    # Water density (kg/m3)
+    pw = 1000.0
+
+    # Saturation vapor pressure (kPa)
+    es = 0.611 * np.exp(17.27 * T / (237.3 + T))
+
+    # Slope of saturation vapor pressure curve (kPa/°C)
+    delta = 4098.0 * es / (T + 237.3) ** 2
+
+    # Latent heat of vaporization (kJ/kg)
+    lv = 2501.0 - 2.37 * T
+
+    # Psychrometric constant (kPa/°C)
+    C_p = 1.005     # kJ kg-1 °C-1
+    p = 101.3       # kPa
+    gamma = C_p * p / 0.622 / lv
+
+    # Priestley–Taylor available energy (W/m2)
+    PET_E = alpha * (R_n - G) * delta / (delta + gamma)
+
+    # Convert energy to evapotranspiration
+    # W/m2 → m/s → mm/day
+    PET = PET_E / lv / pw / 1000.0
+    PET = PET * 1000.0 * 86400.0
+
+    # PET cannot be negative
+    PET = PET
+    PET[PET < 0.0] = 0.0
+
+    return PET

--- a/run_daily_calibration.py
+++ b/run_daily_calibration.py
@@ -4,8 +4,8 @@ run_daily_calibration.py
 Calibrates the CFE hydrologic model for DAILY time steps using the
 snow17 + PET + CFE setup integrated via SPOTPY DDS.
 
-Units: mm/day for both simulated and observed (per Suma's direction).
-Adapted from Abhinav Gupta's setup.
+Units: mm/day for both simulated and observed.
+
 """
 
 import argparse

--- a/run_daily_calibration.py
+++ b/run_daily_calibration.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""
+run_daily_calibration.py
+Calibrates the CFE hydrologic model for DAILY time steps using the
+snow17 + PET + CFE setup integrated via SPOTPY DDS.
+
+Units: mm/day for both simulated and observed (per Suma's direction).
+Adapted from Abhinav Gupta's setup.
+"""
+
+import argparse
+import os
+import time
+import json
+import numpy as np
+import pandas as pd
+import pet
+from spotpy.algorithms import dds
+import SPOTPY_DDS_setup
+import snow17_pet_cfe
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run daily CFE calibration")
+    parser.add_argument('--forcing', type=str, required=True, help="Path to calibration forcing CSV")
+    parser.add_argument('--obs', type=str, required=True, help="Path to calibration observations CSV")
+    parser.add_argument('--test-forcing', type=str, required=True, help="Path to test forcing CSV")
+    parser.add_argument('--test-obs', type=str, required=True, help="Path to test observations CSV")
+    parser.add_argument('--runs', type=int, default=500, help="Number of DDS iterations")
+    parser.add_argument('--out_dir', type=str, default='./results/CFE_results', help="Directory to save results")
+    args = parser.parse_args()
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    basin = '03463300'
+    area_km2 = 113.18356816373296
+    lat = 35.83138889
+    elev = 806.0
+    albedo = 0.20
+    time_step_size = 3600 * 24
+    time_step_units = 'day'
+    warmup_days = 365
+
+    # Model parameters range for calibration (Abhinav's setup)
+    param_range = {                
+        'alpha_PT':  [0.10, 1.74, 0],   
+        'scf': [0.8, 1.2, 0],           
+        'rvs': [1, 1, 0],           
+        'uadj': [0.01, 0.40, 0],       
+        'mbase': [0.8, 2.0, 0],        
+        'mfmax': [0.8, 3.0, 0],        
+        'mfmin': [0.01, 0.79, 0],      
+        'tipm': [0.01, 1.0, 0],        
+        'nmf': [0.04, 0.40, 0],        
+        'plwhc': [0.01, 0.40, 0],      
+        'pxtemp': [-1.0, 1.0, 0],       
+        'pxtemp1': [-1.0, -1.0, 0],    
+        'pxtemp2': [3.0, 3.0, 0],      
+        "bb": [0.1, 21.94, 0],               
+        "satdk":[0.000001, 0.00726, 0],       
+        "satpsi":[0.069, 0.78, 0],          
+        "slop":[0.0001, 1.0, 0],              
+        "smcmax": [0.16, 0.8, 0],         
+        "wltsmc": [0.001, 0.25, 0],         
+        "D": [0.1, 2.0, 0],  
+        "K_lf": [0.01, 1.0, 0],             
+        'alpha_fc': [0.10, 0.50, 0],          
+        'max_gw_storage': [0.01, 0.50, 0],   
+        'Cgw': [24*1.8*10**(-6), 24*1.8*10**(-3), 0],            
+        'expon': [1.0, 8.0, 0],             
+        'K_nash_lateral': [0.0001, 1.0, 0],                   
+        'num_nash_reservoirs_lateral': [1, 4.99, 0],    
+        'K_nash_surface': [0.0001, 1.00, 0],                    
+        'num_nash_reservoirs_surface': [1, 4.99, 0],     
+        'refkdt': [0.1, 8.0, 0],                            
+        'trigger_z_m': [0.25, 0.75, 0]                            
+    }
+
+    print("Loading calibration data...")
+    met_df_cal = pd.read_csv(args.forcing)
+    obs_df_cal = pd.read_csv(args.obs)
+    met_df_cal['time'] = pd.to_datetime(met_df_cal['time'])
+    obs_df_cal['time'] = pd.to_datetime(obs_df_cal['time'])
+    
+    merged_cal = pd.merge(met_df_cal, obs_df_cal, on='time')
+    if 'streamflow' in merged_cal.columns:
+        # Convert streamflow m³/s → mm/day
+        merged_cal['discharge_mm_day'] = merged_cal['streamflow'] * 86400 * 1000 / (area_km2 * 1000000)
+    else:
+        merged_cal['discharge_mm_day'] = 0.0
+
+    met_df_cal = merged_cal.copy()
+    dates_cal = met_df_cal['time']
+    qobs_cal = met_df_cal['discharge_mm_day']
+
+    print(f"  Cal obs stats (mm/day): min={qobs_cal.min():.4f}, max={qobs_cal.max():.4f}, mean={qobs_cal.mean():.4f}")
+
+    print("Loading test data...")
+    met_df_test = pd.read_csv(args.test_forcing)
+    obs_df_test = pd.read_csv(args.test_obs)
+    met_df_test['time'] = pd.to_datetime(met_df_test['time'])
+    obs_df_test['time'] = pd.to_datetime(obs_df_test['time'])
+    
+    merged_test = pd.merge(met_df_test, obs_df_test, on='time')
+    if 'streamflow' in merged_test.columns:
+        merged_test['discharge_mm_day'] = merged_test['streamflow'] * 86400 * 1000 / (area_km2 * 1000000)
+    else:
+        merged_test['discharge_mm_day'] = 0.0
+
+    met_df_test = merged_test.copy()
+    dates_test = met_df_test['time']
+    qobs_test = met_df_test['discharge_mm_day']
+
+    print(f"  Test obs stats (mm/day): min={qobs_test.min():.4f}, max={qobs_test.max():.4f}, mean={qobs_test.mean():.4f}")
+
+    # Compute Net Radiation and G for Calibration
+    Jul_cal = met_df_cal['time'].dt.dayofyear.values
+    met_df_cal['Rn(W/m2)'] = pet.net_radiation(met_df_cal['srad_daily(W/m2)'].values,
+                                               met_df_cal['tmin(C)'].values,
+                                               met_df_cal['tmax(C)'].values,
+                                               elev, lat, Jul_cal,
+                                               met_df_cal['vp(Pa)'].values, albedo)
+    met_df_cal['G(W/m2)'] = 0.0
+
+    # Test
+    Jul_test = met_df_test['time'].dt.dayofyear.values
+    met_df_test['Rn(W/m2)'] = pet.net_radiation(met_df_test['srad_daily(W/m2)'].values,
+                                                met_df_test['tmin(C)'].values,
+                                                met_df_test['tmax(C)'].values,
+                                                elev, lat, Jul_test,
+                                                met_df_test['vp(Pa)'].values, albedo)
+    met_df_test['G(W/m2)'] = 0.0
+
+    initial_snow_state = {'ait': 0.0, 'w_q': 0.0, 'w_i': 0.0, 'deficit': 0}
+    initial_cfe_state = {'gw_initial_storage_m': 0.00, 'soil_initial_storage_m': 0.00}
+
+    print(f"\nStarting SPOTPY DDS Calibration for {args.runs} iterations")
+    print(f"  Units: mm/day (both obs and sim)")
+    spotpy_setup_instance = SPOTPY_DDS_setup.spotpy_setup(
+        param_range, area_km2, warmup_days, 
+        met_df_cal, dates_cal, qobs_cal.values[warmup_days:], 
+        initial_snow_state, initial_cfe_state, lat, elev, time_step_size, time_step_units
+    )
+
+    sampler = dds(spotpy_setup_instance, dbname=os.path.join(args.out_dir, f'all_params_{basin}'), dbformat='csv')
+    sampler.sample(args.runs, trials=1)
+
+    # Re-run best
+    results = pd.read_csv(os.path.join(args.out_dir, f'all_params_{basin}.csv'))
+    best = results.loc[results['like1'].idxmax()]
+
+    params = best
+    pet_params = {'alpha_PT': params['paralpha_PT']}
+    snow_params = {'scf': params['parscf'], 'rvs': params['parrvs'], 'uadj': params['paruadj'], 
+                   'mbase': params['parmbase'], 'mfmax': params['parmfmax'], 'mfmin': params['parmfmin'], 
+                   'tipm': params['partipm'], 'nmf': params['parnmf'], 'plwhc': params['parplwhc'], 
+                   'pxtemp': params['parpxtemp'], 'pxtemp1': params['parpxtemp1'], 'pxtemp2': params['parpxtemp2']}
+    cfg_data = {
+        "catchment_area_km2": area_km2,
+        "partition_scheme": "Schaake",
+        "soil_params": {
+            "bb": params['parbb'], "satdk": params['parsatdk'], "satpsi": params['parsatpsi'], 
+            "slop": params['parslop'], "smcmax": params['parsmcmax'], "wltsmc": params['parwltsmc'], 
+            "D": params['parD'], "K_lf": params['parK_lf'], "alpha_fc": params['paralpha_fc']
+        },
+        "max_gw_storage": params['parmax_gw_storage'], "Cgw": params['parCgw'], "expon": params['parexpon'],
+        "K_nash_lateral": params['parK_nash_lateral'], "nash_storage_lateral": [0.0]*int(params['parnum_nash_reservoirs_lateral']), 
+        "K_nash_surface": params['parK_nash_surface'], "nash_storage_surface": [0.0]*int(params['parnum_nash_reservoirs_surface']), 
+        "refkdt": params['parrefkdt'], 'trigger_z_m': params['partrigger_z_m'],   
+        "soil_scheme": "classic",
+        "stand_alone": 0,
+    }
+
+    # -------- Calibration period --------
+    output_lists, _ = snow17_pet_cfe.run_snow_pet_cfe(met_df_cal, dates_cal, cfg_data,
+                                                      snow_params, pet_params, initial_snow_state, 
+                                                      initial_cfe_state, lat, elev, time_step_size, time_step_units)
+    sim_cal = np.array(output_lists['land_surface_water__runoff_depth']) * 1000.0  # m → mm/day
+    sim_cal = sim_cal[warmup_days:]
+    obs_cal = qobs_cal.values[warmup_days:]
+    dates_cal_plot = dates_cal.values[warmup_days:]
+    nse_cal = 1 - np.sum((obs_cal - sim_cal) ** 2) / np.sum((obs_cal - np.mean(obs_cal)) ** 2)
+
+    # -------- Test period --------
+    output_lists_test, _ = snow17_pet_cfe.run_snow_pet_cfe(met_df_test, dates_test, cfg_data,
+                                                           snow_params, pet_params, initial_snow_state, 
+                                                           initial_cfe_state, lat, elev, time_step_size, time_step_units)
+    sim_test = np.array(output_lists_test['land_surface_water__runoff_depth']) * 1000.0  # m → mm/day
+    obs_test = qobs_test.values
+    dates_test_plot = dates_test.values
+
+    # Handle test warmup: if test period is shorter than warmup_days, don't skip
+    if len(sim_test) > warmup_days:
+        sim_test_eval = sim_test[warmup_days:]
+        obs_test_eval = obs_test[warmup_days:]
+    else:
+        sim_test_eval = sim_test
+        obs_test_eval = obs_test
+
+    if len(obs_test_eval) > 0 and np.var(obs_test_eval) > 0:
+        nse_test = 1 - np.sum((obs_test_eval - sim_test_eval[:len(obs_test_eval)]) ** 2) / np.sum((obs_test_eval - np.mean(obs_test_eval)) ** 2)
+    else:
+        nse_test = float('nan')
+
+    # Save NSE
+    with open(os.path.join(args.out_dir, f'NSE_{basin}.txt'), 'w') as f:
+        f.write(f'Calibration NSE: {nse_cal}\n')
+        f.write(f'Test NSE: {nse_test}\n')
+
+    all_params = {"pet_params": pet_params, "snow_params": snow_params, "cfg_data": cfg_data}
+    with open(os.path.join(args.out_dir, f'theta_opt_{basin}.txt'), 'w') as f:
+        json.dump(all_params, f, indent=4)
+
+    print()
+    print(f"  Calibration NSE: {nse_cal:.4f}")
+    print(f"  Test NSE: {nse_test:.4f}")
+
+    # ================================================================
+    # PLOTS — per Suma's directions: separate panels, obs-only, mm/day
+    # ================================================================
+
+    # --- PLOT 1: Observations only (calibration period) ---
+    fig, ax = plt.subplots(figsize=(15, 4))
+    ax.plot(dates_cal_plot, obs_cal, 'b-', linewidth=0.7, alpha=0.8)
+    ax.set_ylabel('Observed (mm/day)')
+    ax.set_xlabel('Date')
+    ax.set_title(f'Observed Streamflow — Gage {basin} (Daily, Calibration Period)')
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    obs_cal_path = os.path.join(args.out_dir, f'daily_obs_only_cal_{basin}.png')
+    plt.savefig(obs_cal_path, dpi=300, bbox_inches='tight')
+    plt.close()
+    print(f"  Saved: {obs_cal_path}")
+
+    # --- PLOT 2: Observations only (test period) ---
+    fig, ax = plt.subplots(figsize=(12, 4))
+    ax.plot(dates_test_plot, obs_test, 'b-', linewidth=0.7, alpha=0.8, marker='o', markersize=2)
+    ax.set_ylabel('Observed (mm/day)')
+    ax.set_xlabel('Date')
+    ax.set_title(f'Observed Streamflow — Gage {basin} (Daily, Test Period: Hurricane Helene)')
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    obs_test_path = os.path.join(args.out_dir, f'daily_obs_only_test_{basin}.png')
+    plt.savefig(obs_test_path, dpi=300, bbox_inches='tight')
+    plt.close()
+    print(f"  Saved: {obs_test_path}")
+
+    # --- PLOT 3: Calibration - Separate panels (no overlap) ---
+    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(15, 10),
+                                         gridspec_kw={'height_ratios': [2, 2, 1]},
+                                         sharex=True)
+    ax1.plot(dates_cal_plot, obs_cal, 'b-', linewidth=0.7, alpha=0.8)
+    ax1.set_ylabel('Observed (mm/day)')
+    ax1.set_title(f'Daily Calibration — Gage {basin} (NSE = {nse_cal:.4f})')
+    ax1.grid(True, alpha=0.3)
+
+    ax2.plot(dates_cal_plot, sim_cal, 'r-', linewidth=0.7, alpha=0.8)
+    ax2.set_ylabel('Simulated (mm/day)')
+    ax2.grid(True, alpha=0.3)
+
+    residuals_cal = sim_cal - obs_cal
+    ax3.bar(dates_cal_plot, residuals_cal, width=1.0, color='gray', alpha=0.4)
+    ax3.axhline(0, color='k', linewidth=0.5)
+    ax3.set_ylabel('Residual (mm/day)')
+    ax3.set_xlabel('Date')
+    ax3.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    cal_sep_path = os.path.join(args.out_dir, f'daily_separate_cal_{basin}.png')
+    plt.savefig(cal_sep_path, dpi=300, bbox_inches='tight')
+    plt.close()
+    print(f"  Saved: {cal_sep_path}")
+
+    # --- PLOT 4: Test - Separate panels (no overlap) ---
+    min_test = min(len(sim_test), len(obs_test))
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 8), sharex=True)
+
+    ax1.plot(dates_test_plot[:min_test], obs_test[:min_test], 'b-', linewidth=0.7, alpha=0.8, marker='o', markersize=3)
+    ax1.set_ylabel('Observed (mm/day)')
+    ax1.set_title(f'Daily Test (Hurricane Helene) — Gage {basin} (NSE = {nse_test:.4f})')
+    ax1.grid(True, alpha=0.3)
+
+    ax2.plot(dates_test_plot[:min_test], sim_test[:min_test], 'r-', linewidth=0.7, alpha=0.8, marker='x', markersize=3)
+    ax2.set_ylabel('Simulated (mm/day)')
+    ax2.set_xlabel('Date')
+    ax2.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    test_sep_path = os.path.join(args.out_dir, f'daily_separate_test_{basin}.png')
+    plt.savefig(test_sep_path, dpi=300, bbox_inches='tight')
+    plt.close()
+    print(f"  Saved: {test_sep_path}")
+
+    # --- PLOT 5: Overlay (for quick comparison) ---
+    fig, ax = plt.subplots(figsize=(15, 5))
+    ax.plot(dates_cal_plot, obs_cal, 'b-', linewidth=0.7, alpha=0.7, label='Observed')
+    ax.plot(dates_cal_plot, sim_cal, 'r--', linewidth=0.7, alpha=0.7, label='Simulated')
+    ax.set_ylabel('Streamflow (mm/day)')
+    ax.set_xlabel('Date')
+    ax.set_title(f'Daily Calibration — Gage {basin} (NSE = {nse_cal:.4f})')
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    cal_overlay_path = os.path.join(args.out_dir, f'daily_overlay_cal_{basin}.png')
+    plt.savefig(cal_overlay_path, dpi=300, bbox_inches='tight')
+    plt.close()
+    print(f"  Saved: {cal_overlay_path}")
+
+    # Sanity check
+    print(f"\n  SANITY CHECK (mm/day):")
+    print(f"    Obs cal peaks: max={obs_cal.max():.2f} mm/day")
+    print(f"    Sim cal peaks: max={sim_cal.max():.2f} mm/day")
+    print(f"    Obs test peaks: max={obs_test.max():.2f} mm/day")
+    print(f"    (Suma expects max ~60-70 mm/day for CAMELS gauges)")
+
+    print(f"\n  Results saved to {args.out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run_daily_testrun.py
+++ b/run_daily_testrun.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+run_daily_testrun.py
+Evaluates the daily Snow17+PET+CFE model on a test period using
+previously calibrated parameters saved by run_daily_calibration.py.
+
+Units: mm/day for both simulated and observed (per Suma's direction).
+
+Usage:
+    python run_daily_testrun.py \
+        --params ./results/theta_opt_03463300.txt \
+        --test-forcing ./gage_03463300_data/forcing_test.csv \
+        --test-obs ./gage_03463300_data/obs_usgs_daily_test.csv \
+        --out_dir ./results/test_run
+"""
+
+import argparse
+import os
+import json
+import numpy as np
+import pandas as pd
+import pet
+import snow17_pet_cfe
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def compute_nse(obs, sim):
+    return 1 - np.sum((obs - sim) ** 2) / np.sum((obs - np.mean(obs)) ** 2)
+
+
+def compute_kge(obs, sim):
+    r = np.corrcoef(obs, sim)[0, 1]
+    alpha = np.std(sim) / np.std(obs)
+    beta = np.mean(sim) / np.mean(obs)
+    return 1 - np.sqrt((r - 1) ** 2 + (alpha - 1) ** 2 + (beta - 1) ** 2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test daily CFE with best calibrated params")
+    parser.add_argument('--params', type=str, required=True,
+                        help="Path to calibrated params JSON (theta_opt_*.txt from calibration)")
+    parser.add_argument('--test-forcing', type=str, required=True,
+                        help="Path to test period forcing CSV")
+    parser.add_argument('--test-obs', type=str, required=True,
+                        help="Path to test period observations CSV")
+    parser.add_argument('--out_dir', type=str, default='./results/test_run',
+                        help="Directory to save results")
+    args = parser.parse_args()
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    basin = '03463300'
+    area_km2 = 113.18356816373296
+    lat = 35.83138889
+    elev = 806.0
+    albedo = 0.20
+    time_step_size = 3600 * 24
+    time_step_units = 'day'
+
+    # Load calibrated parameters
+    print(f"Loading calibrated params from: {args.params}")
+    with open(args.params, 'r') as f:
+        all_params = json.load(f)
+    pet_params = all_params['pet_params']
+    snow_params = all_params['snow_params']
+    cfg_data = all_params['cfg_data']
+    print(f"  alpha_PT={pet_params['alpha_PT']:.4f}, scf={snow_params['scf']:.4f}")
+
+    # Load test forcing and observations
+    print("Loading test data...")
+    met_df = pd.read_csv(args.test_forcing)
+    obs_df = pd.read_csv(args.test_obs)
+    met_df['time'] = pd.to_datetime(met_df['time'])
+    obs_df['time'] = pd.to_datetime(obs_df['time'])
+
+    merged = pd.merge(met_df, obs_df, on='time')
+    if 'streamflow' in merged.columns:
+        merged['discharge_mm_day'] = merged['streamflow'] * 86400 * 1000 / (area_km2 * 1_000_000)
+    else:
+        merged['discharge_mm_day'] = 0.0
+
+    dates = merged['time']
+    qobs = merged['discharge_mm_day']
+    print(f"  {len(merged)} days, obs range: {qobs.min():.3f}–{qobs.max():.3f} mm/day")
+
+    # Compute net radiation
+    Jul = dates.dt.dayofyear.values
+    merged['Rn(W/m2)'] = pet.net_radiation(
+        merged['srad_daily(W/m2)'].values, merged['tmin(C)'].values,
+        merged['tmax(C)'].values, elev, lat, Jul, merged['vp(Pa)'].values, albedo)
+    merged['G(W/m2)'] = 0.0
+
+    # Run Snow17 + PET + CFE
+    print("Running Snow17 + PET + CFE...")
+    initial_snow_state = {'ait': 0.0, 'w_q': 0.0, 'w_i': 0.0, 'deficit': 0}
+    initial_cfe_state = {'gw_initial_storage_m': 0.00, 'soil_initial_storage_m': 0.00}
+
+    output_lists, _ = snow17_pet_cfe.run_snow_pet_cfe(
+        merged, dates, cfg_data, snow_params, pet_params,
+        initial_snow_state, initial_cfe_state, lat, elev, time_step_size, time_step_units)
+
+    sim = np.array(output_lists['land_surface_water__runoff_depth']) * 1000.0  # m → mm/day
+    obs = qobs.values
+
+    # Align lengths
+    n = min(len(sim), len(obs))
+    sim, obs, dates_plot = sim[:n], obs[:n], dates.values[:n]
+
+    # Metrics — skip if obs has no variance (e.g. very short test period)
+    if np.var(obs) > 0:
+        nse = compute_nse(obs, sim)
+        kge = compute_kge(obs, sim)
+    else:
+        nse, kge = float('nan'), float('nan')
+
+    print(f"\n  Test NSE : {nse:.4f}")
+    print(f"  Test KGE : {kge:.4f}")
+    print(f"  Obs  max : {obs.max():.2f} mm/day")
+    print(f"  Sim  max : {sim.max():.2f} mm/day")
+
+    # Save metrics
+    metrics_path = os.path.join(args.out_dir, f'test_metrics_{basin}.txt')
+    with open(metrics_path, 'w') as f:
+        f.write(f'Test NSE: {nse}\n')
+        f.write(f'Test KGE: {kge}\n')
+    print(f"  Saved: {metrics_path}")
+
+    # Plot 1: Observed only
+    fig, ax = plt.subplots(figsize=(12, 4))
+    ax.plot(dates_plot, obs, 'b-', linewidth=0.8, alpha=0.85, marker='o', markersize=2)
+    ax.set_ylabel('Observed (mm/day)')
+    ax.set_xlabel('Date')
+    ax.set_title(f'Observed Streamflow — Gage {basin} (Daily, Test Period)')
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(os.path.join(args.out_dir, f'test_obs_only_{basin}.png'), dpi=300, bbox_inches='tight')
+    plt.close()
+
+    # Plot 2: Separate panels — obs / sim / residual
+    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(12, 10),
+                                         gridspec_kw={'height_ratios': [2, 2, 1]}, sharex=True)
+    ax1.plot(dates_plot, obs, 'b-', linewidth=0.8, alpha=0.85)
+    ax1.set_ylabel('Observed (mm/day)')
+    ax1.set_title(f'Daily Test Run — Gage {basin}  NSE={nse:.4f}  KGE={kge:.4f}')
+    ax1.grid(True, alpha=0.3)
+
+    ax2.plot(dates_plot, sim, 'r-', linewidth=0.8, alpha=0.85)
+    ax2.set_ylabel('Simulated (mm/day)')
+    ax2.grid(True, alpha=0.3)
+
+    residuals = sim - obs
+    ax3.bar(dates_plot, residuals, width=1.0, color='gray', alpha=0.4)
+    ax3.axhline(0, color='k', linewidth=0.5)
+    ax3.set_ylabel('Residual (mm/day)')
+    ax3.set_xlabel('Date')
+    ax3.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    plt.savefig(os.path.join(args.out_dir, f'test_separate_{basin}.png'), dpi=300, bbox_inches='tight')
+    plt.close()
+
+    # Plot 3: Overlay
+    fig, ax = plt.subplots(figsize=(12, 5))
+    ax.plot(dates_plot, obs, 'b-', linewidth=0.8, alpha=0.75, label='Observed')
+    ax.plot(dates_plot, sim, 'r--', linewidth=0.8, alpha=0.75, label='Simulated')
+    ax.set_ylabel('Streamflow (mm/day)')
+    ax.set_xlabel('Date')
+    ax.set_title(f'Daily Test Run — Gage {basin}  NSE={nse:.4f}  KGE={kge:.4f}')
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(os.path.join(args.out_dir, f'test_overlay_{basin}.png'), dpi=300, bbox_inches='tight')
+    plt.close()
+
+    print(f"\n  All plots saved to {args.out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/snow17_pet_cfe.py
+++ b/snow17_pet_cfe.py
@@ -1,0 +1,60 @@
+"""
+Define a function that runs Snow module, PET computation, and CFE
+
+Author: Abhinav Gupta (Created: 9 Feb 2026)
+"""
+
+import numpy as np
+import pandas as pd
+import json
+import matplotlib.pyplot as plt
+import bmi_cfe_daily as bmi_cfe
+import pet
+from tonic.tonic.models.snow17 import snow17 
+
+def run_snow_pet_cfe(met_df, dates, cfg_data, snow_params, pet_params, initial_snow_state, initial_cfe_state, lat, elev, time_step_size, time_step_units):
+    
+    
+    swe, outflow = snow17.snow17(dates.dt.to_pydatetime(), met_df['prcp(mm/day)'].values, met_df['tavg(C)'].values, lat=lat, elevation=elev, dt=24, 
+                                scf=snow_params['scf'], rvs=snow_params['rvs'], 
+                                uadj=snow_params['uadj'], mbase=snow_params['mbase'], mfmax=snow_params['mfmax'], mfmin=snow_params['mfmin'], 
+                                tipm=snow_params['tipm'], nmf=snow_params['nmf'],
+                                plwhc=snow_params['plwhc'], pxtemp=snow_params['pxtemp'], pxtemp1=snow_params['pxtemp1'], 
+                                pxtemp2=snow_params['pxtemp2'])       # Precip input should be in mm/day, temperature in degree C, dt in hours, 
+    EP_m_per_day = outflow / 1000.0     # Convert from mm/day to m/day
+    
+    final_snow_state = ''
+
+    # Compute PET using Priestley-Taylor method
+    pet_mm_per_day = pet.priestley_taylor_fixed_alpha(met_df['Rn(W/m2)'].values, met_df['G(W/m2)'].values, 
+                                                                met_df['tavg(C)'].values, alpha = pet_params['alpha_PT'])  # PET in mm/day
+
+    # Convert alpha from mm/day to m/s
+    pet_m_per_s = pet_mm_per_day / 1000.0 / time_step_size
+
+    # Instantiate and initialize CFE model
+    first_date = dates.iloc[0]
+    year = first_date.year
+    month = first_date.month
+    day = first_date.day
+
+    cfe_instance = bmi_cfe.BMI_CFE(cfg_data=cfg_data, time_step_size=time_step_size, time_step_units = time_step_units)
+    cfe_instance.initialize(current_year = year, current_month = month, current_day = day, ############################################### update these dates
+                            initial_state={'gw_reservoir_initial_storage_m': initial_cfe_state['gw_initial_storage_m'], 
+                                           'soil_reservoir_initial_storage_m': initial_cfe_state['soil_initial_storage_m'],})
+        
+    outputs = cfe_instance.get_output_var_names()
+    output_lists = {output:[] for output in outputs}
+
+    # Run CFE model for the calibration period
+    for (precip_time_integrated, pet_rate) in zip(EP_m_per_day, pet_m_per_s):############################################################################# MODIFY to INTEGRATE SNOW MODEL
+        
+        cfe_instance.set_value('atmosphere_water__time_integral_of_precipitation_mass_flux', precip_time_integrated)    # Set value of the precipitation (total during the timestep) for the current timestep
+        cfe_instance.set_value('water_potential_evaporation_flux', pet_rate)           # Set value of the PET rate (in m per second) for the current timestep
+
+        cfe_instance.update()
+        
+        for output in outputs:
+            output_lists[output].append(cfe_instance.get_value(output))
+    
+    return output_lists, final_snow_state


### PR DESCRIPTION
Adds daily Snow17+PET+CFE calibration workflow for USGS gage 03463300 (South Toe River, NC).

## Files added
- `download_usgs_obs.py` — downloads and converts USGS streamflow CFS to mm/day
- `run_daily_calibration.py` — SPOTPY DDS calibration, saves best params and plots
- `run_daily_testrun.py` — standalone test run using saved calibrated params
- `SPOTPY_DDS_setup.py` — 31-parameter search space definition
- `snow17_pet_cfe.py` — couples Snow17 + PET + CFE
- `pet.py` — Priestley-Taylor PET computation
- `example_gage03463300_config_cfe.json` — example CFE config for this gage

## Results (gage 03463300)
- Calibration NSE: 0.468 (2018-2022)
- Test NSE: 0.090 (Sep-Oct 2024, Hurricane Helene)